### PR TITLE
Cycle through source, preview and reading mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ and live preview), rather than relying on the default toggle behaviour.
 | Mode manager: Switch to live preview | Switch to live preview mode (edit with formatting preview)          | `mode-manager:switch-to-live-preview` |
 | Mode manager: Switch to source       | Switch to source only edit mode                                     | `mode-manager:switch-to-source`       |
 | Mode manager: Switch to edit         | Switch to edit mode and maintain existing source or preview setting | `mode-manager:switch-to-edit`         |
+| Mode manager: Switch to next mode    | Cycle through modes in sequential order: reading, source, preview   | `mode-manager:switch-to-next-mode`    |
 
 
 ## Special properties

--- a/src/main.ts
+++ b/src/main.ts
@@ -83,6 +83,13 @@ export default class ModeManager extends Plugin {
             checkCallback: this.makeCheckCB(view => this.setMode("reading", view))
         });
 
+        this.addCommand({
+            id: "switch-to-next-mode",
+            name: "Switch to next mode",
+            checkCallback: this.makeCheckCB(view => this.nextMode(view))
+        });
+
+
         this.registerEvent(
             this.app.workspace.on("active-leaf-change", leaf => {
                 const view = leaf?.view;
@@ -121,6 +128,35 @@ export default class ModeManager extends Plugin {
         await view.setState(state, { history: true });
         this.app.workspace.trigger("layout-change");
     }
+
+    async nextMode(view: MarkdownView) {
+        const state = view.getState();
+        let mode: ModeValue;
+        if (state.mode === "preview") {
+            mode = "reading";
+        } else {
+            // don't cycle into edit mode, only the sub-modes
+            if (state.source === true) {
+                mode = "source";
+            } else {
+                mode = "preview";
+            }
+        }
+
+        switch (mode) {
+            case "reading":
+                await this.setMode("source", view);
+                break;
+            case "source":
+                await this.setMode("preview", view);
+                break;
+            case "preview":
+                await this.setMode("reading", view);
+                break;
+        }
+    }
+
+
 
     getView() {
         return this.app.workspace.getActiveViewOfType(MarkdownView);

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,28 +131,18 @@ export default class ModeManager extends Plugin {
 
     async nextMode(view: MarkdownView) {
         const state = view.getState();
-        let mode: ModeValue;
         if (state.mode === "preview") {
-            mode = "reading";
+            // from reading
+            await this.setMode("source", view);
         } else {
             // don't cycle into edit mode, only the sub-modes
             if (state.source === true) {
-                mode = "source";
-            } else {
-                mode = "preview";
-            }
-        }
-
-        switch (mode) {
-            case "reading":
-                await this.setMode("source", view);
-                break;
-            case "source":
+                // from source
                 await this.setMode("preview", view);
-                break;
-            case "preview":
+            } else {
+                // from preview
                 await this.setMode("reading", view);
-                break;
+            }
         }
     }
 


### PR DESCRIPTION
This adds a command to switch to the next mode, in a sequence of source, preview then reading mode.

This allows to use one keyboard shortcut to access all modes.